### PR TITLE
Add upload icons and improve BU/LOB selection display

### DIFF
--- a/src/components/dashboard/bu-lob-selector.tsx
+++ b/src/components/dashboard/bu-lob-selector.tsx
@@ -186,7 +186,7 @@ export default function BuLobSelector({
                     {compact ? (
                         <>
                           <Plug className="h-4 w-4" />
-                          <span>{triggerLabel ?? 'Connectors'}</span>
+                          <span>{selectedBu && selectedLob ? `${selectedBu.name} - ${selectedLob.name}` : (triggerLabel ?? 'Connectors')}</span>
                           <span
                             role="button"
                             tabIndex={selectedLob ? 0 : -1}
@@ -204,7 +204,7 @@ export default function BuLobSelector({
                     ) : (
                         <>
                           <span>
-                            {selectedBu ? `${selectedBu.name} / ${selectedLob?.name || 'Select LOB'}` : 'Select a Business Unit'}
+                            {selectedBu && selectedLob ? `${selectedBu.name} - ${selectedLob.name}` : (selectedBu ? selectedBu.name : 'Select a Business Unit')}
                           </span>
                           <span
                             role="button"

--- a/src/components/dashboard/bu-lob-selector.tsx
+++ b/src/components/dashboard/bu-lob-selector.tsx
@@ -187,6 +187,15 @@ export default function BuLobSelector({
                         <>
                           <Plug className="h-4 w-4" />
                           <span>{triggerLabel ?? 'Connectors'}</span>
+                          <button
+                            className="ml-1 inline-flex items-center justify-center rounded p-1 hover:bg-white/10 disabled:opacity-50"
+                            title={selectedLob ? `Attach CSV/Excel to ${selectedLob.name}` : 'Select a BU/LOB first'}
+                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); if (selectedLob) handleUploadClick(selectedLob.id); }}
+                            disabled={!selectedLob}
+                          >
+                            <UploadCloud className="h-4 w-4" />
+                            <span className="sr-only">Attach CSV/Excel</span>
+                          </button>
                           <ChevronDown className="h-4 w-4" />
                         </>
                     ) : (
@@ -194,6 +203,15 @@ export default function BuLobSelector({
                           <span>
                             {selectedBu ? `${selectedBu.name} / ${selectedLob?.name || 'Select LOB'}` : 'Select a Business Unit'}
                           </span>
+                          <button
+                            className="ml-1 inline-flex items-center justify-center rounded p-1 hover:bg-white/10 disabled:opacity-50"
+                            title={selectedLob ? `Attach CSV/Excel to ${selectedLob.name}` : 'Select a BU/LOB first'}
+                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); if (selectedLob) handleUploadClick(selectedLob.id); }}
+                            disabled={!selectedLob}
+                          >
+                            <UploadCloud className="h-4 w-4" />
+                            <span className="sr-only">Attach CSV/Excel</span>
+                          </button>
                           <ChevronDown className="h-4 w-4" />
                         </>
                     )}

--- a/src/components/dashboard/bu-lob-selector.tsx
+++ b/src/components/dashboard/bu-lob-selector.tsx
@@ -14,12 +14,13 @@ import {
   DropdownMenuPortal,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { ChevronDown, Folder, PlusCircle, UploadCloud, CheckCircle, FileWarning, Plug } from 'lucide-react';
+import { ChevronDown, Folder, PlusCircle, UploadCloud, CheckCircle, FileWarning, Plug, Check } from 'lucide-react';
 import { useApp } from './app-provider';
 import type { BusinessUnit, LineOfBusiness } from '@/lib/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { cn } from '@/lib/utils';
 
 function AddBuDialog({ isOpen, onOpenChange }: { isOpen: boolean, onOpenChange: (isOpen: boolean) => void }) {
     const [name, setName] = useState('');
@@ -181,7 +182,7 @@ export default function BuLobSelector({
         <>
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button variant={variant as any} size={size as any} className={className ?? "text-white hover:bg-white/20 hover:text-white flex items-center gap-2"}>
+                <Button variant={variant as any} size={size as any} className={className ?? 'text-white hover:bg-white/20 hover:text-white flex items-center gap-2'}>
                     {compact ? (
                         <>
                           <Plug className="h-4 w-4" />
@@ -204,21 +205,52 @@ export default function BuLobSelector({
                 {businessUnits.map((bu) => (
                     <DropdownMenuSub key={bu.id}>
                         <DropdownMenuSubTrigger>
-                            <Folder className="mr-2 h-4 w-4" style={{ color: bu.color }}/>
-                            <span>{bu.name}</span>
+                            <div className="flex items-center gap-2">
+                                <Folder className="mr-2 h-4 w-4" style={{ color: bu.color }}/>
+                                <span>{bu.name}</span>
+                            </div>
+                            {selectedBu?.id === bu.id && (
+                                <span className="ml-auto text-xs text-muted-foreground">Current</span>
+                            )}
                         </DropdownMenuSubTrigger>
                         <DropdownMenuPortal>
                             <DropdownMenuSubContent>
                                 <DropdownMenuLabel>{bu.name}</DropdownMenuLabel>
                                 <DropdownMenuSeparator />
-                                {bu.lobs.map((lob) => (
-                                    <DropdownMenuItem key={lob.id} onSelect={() => handleLobSelect(lob, bu)}>
-                                        <div className="flex items-center justify-between w-full">
-                                            <span>{lob.name}</span>
-                                            {lob.hasData ? <CheckCircle className="h-4 w-4 text-green-500" /> : <FileWarning className="h-4 w-4 text-amber-500" />}
-                                        </div>
-                                    </DropdownMenuItem>
-                                ))}
+                                {bu.lobs.map((lob) => {
+                                    const isSelected = selectedLob?.id === lob.id;
+                                    return (
+                                        <DropdownMenuItem
+                                            key={lob.id}
+                                            onSelect={() => handleLobSelect(lob, bu)}
+                                            className={cn(isSelected && 'bg-accent text-accent-foreground')}
+                                        >
+                                            <div className="flex items-center justify-between w-full">
+                                                <div className="flex items-center gap-2">
+                                                    {isSelected && <Check className="h-4 w-4 text-primary" />}
+                                                    <span>{lob.name}</span>
+                                                </div>
+                                                <div className="flex items-center gap-2">
+                                                    {lob.hasData ? (
+                                                        <CheckCircle className="h-4 w-4 text-green-500" />
+                                                    ) : (
+                                                        <FileWarning className="h-4 w-4 text-amber-500" />
+                                                    )}
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-6 w-6"
+                                                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleUploadClick(lob.id); }}
+                                                        title="Attach CSV/Excel"
+                                                    >
+                                                        <UploadCloud className="h-4 w-4" />
+                                                        <span className="sr-only">Attach CSV/Excel</span>
+                                                    </Button>
+                                                </div>
+                                            </div>
+                                        </DropdownMenuItem>
+                                    );
+                                })}
                                 {bu.lobs.length === 0 && (
                                     <DropdownMenuItem disabled>No LOBs created yet.</DropdownMenuItem>
                                 )}

--- a/src/components/dashboard/bu-lob-selector.tsx
+++ b/src/components/dashboard/bu-lob-selector.tsx
@@ -187,15 +187,18 @@ export default function BuLobSelector({
                         <>
                           <Plug className="h-4 w-4" />
                           <span>{triggerLabel ?? 'Connectors'}</span>
-                          <button
-                            className="ml-1 inline-flex items-center justify-center rounded p-1 hover:bg-white/10 disabled:opacity-50"
+                          <span
+                            role="button"
+                            tabIndex={selectedLob ? 0 : -1}
+                            aria-disabled={!selectedLob}
+                            className={cn('ml-1 inline-flex items-center justify-center rounded p-1 hover:bg-white/10', !selectedLob && 'opacity-50 pointer-events-none')}
                             title={selectedLob ? `Attach CSV/Excel to ${selectedLob.name}` : 'Select a BU/LOB first'}
                             onClick={(e) => { e.preventDefault(); e.stopPropagation(); if (selectedLob) handleUploadClick(selectedLob.id); }}
-                            disabled={!selectedLob}
+                            onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && selectedLob) { e.preventDefault(); e.stopPropagation(); handleUploadClick(selectedLob.id); } }}
                           >
                             <UploadCloud className="h-4 w-4" />
                             <span className="sr-only">Attach CSV/Excel</span>
-                          </button>
+                          </span>
                           <ChevronDown className="h-4 w-4" />
                         </>
                     ) : (
@@ -203,15 +206,18 @@ export default function BuLobSelector({
                           <span>
                             {selectedBu ? `${selectedBu.name} / ${selectedLob?.name || 'Select LOB'}` : 'Select a Business Unit'}
                           </span>
-                          <button
-                            className="ml-1 inline-flex items-center justify-center rounded p-1 hover:bg-white/10 disabled:opacity-50"
+                          <span
+                            role="button"
+                            tabIndex={selectedLob ? 0 : -1}
+                            aria-disabled={!selectedLob}
+                            className={cn('ml-1 inline-flex items-center justify-center rounded p-1 hover:bg-white/10', !selectedLob && 'opacity-50 pointer-events-none')}
                             title={selectedLob ? `Attach CSV/Excel to ${selectedLob.name}` : 'Select a BU/LOB first'}
                             onClick={(e) => { e.preventDefault(); e.stopPropagation(); if (selectedLob) handleUploadClick(selectedLob.id); }}
-                            disabled={!selectedLob}
+                            onKeyDown={(e) => { if ((e.key === 'Enter' || e.key === ' ') && selectedLob) { e.preventDefault(); e.stopPropagation(); handleUploadClick(selectedLob.id); } }}
                           >
                             <UploadCloud className="h-4 w-4" />
                             <span className="sr-only">Attach CSV/Excel</span>
-                          </button>
+                          </span>
                           <ChevronDown className="h-4 w-4" />
                         </>
                     )}

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Settings, User, Bot, BarChart, Sun, Moon, FileText, Printer } from 'lucide-react';
+import { Settings, User, Bot, BarChart, Sun, Moon, FileText, Printer, UploadCloud } from 'lucide-react';
 import placeholderImages from '@/lib/placeholder-images.json';
 import { useApp } from './app-provider';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -160,16 +160,44 @@ export default function Header() {
         
         <div className="flex items-center space-x-4">
              <ThemeToggle />
-            <button 
+            <button
                 onClick={showAgentMonitor}
                 className="p-2 rounded-lg bg-white/10 hover:bg-white/20"
                 title="Show Agent Monitor"
             >
                 <Bot className="w-5 h-5" />
             </button>
-            
+
+            <button
+                onClick={() => {
+                    // If no LOB selected, do nothing
+                    if (!state.selectedLob) return;
+                    const input = document.getElementById('header-upload-input') as HTMLInputElement | null;
+                    input?.click();
+                }}
+                className="p-2 rounded-lg bg-white/10 hover:bg-white/20 disabled:opacity-50"
+                title={state.selectedLob ? `Attach CSV/Excel to ${state.selectedLob.name}` : 'Select a BU/LOB first'}
+                disabled={!state.selectedLob}
+            >
+                <UploadCloud className="w-5 h-5" />
+            </button>
+            <input
+                id="header-upload-input"
+                type="file"
+                className="hidden"
+                accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"
+                onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file && state.selectedLob) {
+                        dispatch({ type: 'UPLOAD_DATA', payload: { lobId: state.selectedLob.id, file } });
+                        // reset value so the same file can be selected twice if needed
+                        e.currentTarget.value = '';
+                    }
+                }}
+            />
+
             <SettingsDropdown onGenerateReport={handleGenerateReport} isReportGenerating={isReportGenerating} />
-            
+
             <div className="w-3 h-3 bg-green-400 rounded-full" title="System Online"></div>
 
             <DropdownMenu>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UX improvements for the BU/LOB connector interface:
- Show visual indication when a BU/LOB is selected instead of generic "Connectors" text
- Add upload/attach icons throughout the interface for CSV/Excel file uploads
- Improve the selection state visibility in dropdown menus
- Enable file attachment functionality directly from the header and connector buttons

## Code changes

**BU/LOB Selector Component (`bu-lob-selector.tsx`):**
- Updated trigger button text to display selected BU-LOB format (e.g., "ECOM-Phone") instead of generic "Connectors"
- Added upload cloud icons next to connector buttons with proper accessibility attributes
- Enhanced dropdown menu items with visual selection indicators (check marks and highlighting)
- Added individual upload buttons for each LOB in the dropdown menu
- Improved styling with conditional classes for selected states

**Header Component (`header.tsx`):**
- Added new upload button in header toolbar with conditional enabling based on LOB selection
- Implemented hidden file input with CSV/Excel file type restrictions
- Added proper file handling and state management for uploads
- Integrated upload functionality with existing app state dispatch system

**Visual Improvements:**
- Added "Current" labels for selected business units
- Enhanced hover states and accessibility for upload buttons
- Improved spacing and layout of dropdown menu itemsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc950595c180414d95bbeeb266c5c6a3/aura-garden)

👀 [Preview Link](https://dc950595c180414d95bbeeb266c5c6a3-aura-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc950595c180414d95bbeeb266c5c6a3</projectId>-->
<!--<branchName>aura-garden</branchName>-->