### PR TITLE
Fix prompt syntax and enhance data panel with tabs

### DIFF
--- a/src/ai/flows/chatbot-summarize-data.ts
+++ b/src/ai/flows/chatbot-summarize-data.ts
@@ -32,7 +32,7 @@ const prompt = ai.definePrompt({
   name: 'summarizeUploadedDataPrompt',
   input: {schema: SummarizeUploadedDataInputSchema},
   output: {schema: SummarizeUploadedDataOutputSchema},
-  prompt: `You are a data analysis expert. Please provide a summary of the following data, including key statistics and data quality indicators. The data is in {{{fileType}}} format.\n\nData:\n{{{data}}}',
+  prompt: `You are a data analysis expert. Please provide a summary of the following data, including key statistics and data quality indicators. The data is in {{{fileType}}} format.\n\nData:\n{{{data}}}`,
 });
 
 const summarizeUploadedDataFlow = ai.defineFlow(

--- a/src/components/dashboard/app-provider.tsx
+++ b/src/components/dashboard/app-provider.tsx
@@ -121,6 +121,14 @@ function appReducer(state: AppState, action: Action): AppState {
         return { ...state, agentMonitor: { ...state.agentMonitor, isOpen: action.payload } };
     case 'SET_DATA_PANEL_OPEN':
         return { ...state, dataPanelOpen: action.payload };
+    case 'SET_DATA_PANEL_MODE':
+        return { ...state, dataPanelMode: action.payload };
+    case 'SET_DATA_PANEL_TARGET':
+        return { ...state, dataPanelTarget: action.payload };
+    case 'SET_DATA_PANEL_WIDTH': {
+        const w = Math.min(70, Math.max(20, Math.round(action.payload)));
+        return { ...state, dataPanelWidthPct: w };
+    }
     case 'END_ONBOARDING':
         return { ...state, isOnboarding: false };
     case 'QUEUE_USER_PROMPT':

--- a/src/components/dashboard/app-provider.tsx
+++ b/src/components/dashboard/app-provider.tsx
@@ -14,6 +14,9 @@ type AppState = {
   isProcessing: boolean;
   agentMonitor: AgentMonitorProps;
   dataPanelOpen: boolean;
+  dataPanelMode: 'chart' | 'table' | 'menu';
+  dataPanelTarget: 'units' | 'revenue';
+  dataPanelWidthPct: number; // 20 - 70
   isOnboarding: boolean;
   queuedUserPrompt?: string | null;
 };
@@ -33,6 +36,9 @@ type Action =
   | { type: 'UPLOAD_DATA', payload: { lobId: string, file: File } }
   | { type: 'TOGGLE_VISUALIZATION', payload: { messageId: string } }
   | { type: 'SET_DATA_PANEL_OPEN'; payload: boolean }
+  | { type: 'SET_DATA_PANEL_MODE'; payload: 'chart' | 'table' | 'menu' }
+  | { type: 'SET_DATA_PANEL_TARGET'; payload: 'units' | 'revenue' }
+  | { type: 'SET_DATA_PANEL_WIDTH'; payload: number }
   | { type: 'END_ONBOARDING' }
   | { type: 'QUEUE_USER_PROMPT'; payload: string }
   | { type: 'CLEAR_QUEUED_PROMPT' };

--- a/src/components/dashboard/app-provider.tsx
+++ b/src/components/dashboard/app-provider.tsx
@@ -61,6 +61,9 @@ const initialState: AppState = {
     isOpen: false,
   },
   dataPanelOpen: false,
+  dataPanelMode: 'chart',
+  dataPanelTarget: 'units',
+  dataPanelWidthPct: 40,
   isOnboarding: true,
   queuedUserPrompt: null,
 };

--- a/src/components/dashboard/app-provider.tsx
+++ b/src/components/dashboard/app-provider.tsx
@@ -84,10 +84,13 @@ function appReducer(state: AppState, action: Action): AppState {
     case 'SET_SELECTED_LOB':
         const isStillProcessingOnLobChange = state.workflow.some(step => step.status === 'active' || step.status === 'pending');
         return { ...state, selectedLob: action.payload, workflow: [], isProcessing: isStillProcessingOnLobChange };
-    case 'ADD_MESSAGE':
+    case 'ADD_MESSAGE': {
       // Remove typing indicator before adding new message
       const messages = state.messages.filter(m => !m.isTyping);
-      return { ...state, messages: [...messages, action.payload] };
+      const last = messages[messages.length - 1];
+      const isDuplicate = last && last.role === action.payload.role && last.content.trim() === action.payload.content.trim();
+      return isDuplicate ? state : { ...state, messages: [...messages, action.payload] };
+    }
     case 'UPDATE_LAST_MESSAGE':
         const updatedMessages = [...state.messages];
         const lastMessageIndex = updatedMessages.length - 1;

--- a/src/components/dashboard/chat-panel.tsx
+++ b/src/components/dashboard/chat-panel.tsx
@@ -330,6 +330,10 @@ export default function ChatPanel({ className }: { className?: string }) {
     };
     
     const handleVisualizeClick = (messageId: string) => {
+      const msg = state.messages.find(m => m.id === messageId);
+      const target = msg?.visualization?.target ?? 'units';
+      dispatch({ type: 'SET_DATA_PANEL_TARGET', payload: target });
+      dispatch({ type: 'SET_DATA_PANEL_MODE', payload: 'chart' });
       dispatch({ type: 'SET_DATA_PANEL_OPEN', payload: true });
       dispatch({ type: 'TOGGLE_VISUALIZATION', payload: { messageId } });
     };

--- a/src/components/dashboard/chat-panel.tsx
+++ b/src/components/dashboard/chat-panel.tsx
@@ -277,16 +277,24 @@ export default function ChatPanel({ className }: { className?: string }) {
                     .filter(s => s.length > 0);
             }
             
-            let visualization;
-            const keywords = ['analyze', 'forecast', 'data', 'visualize'];
-            const shouldVisualize = keywords.some(keyword => messageText.toLowerCase().includes(keyword) || content.toLowerCase().includes(keyword));
+            const inferTargetFromText = (txt: string): 'units' | 'revenue' => {
+              return /(revenue|sales|amount|gmv|income)/i.test(txt) ? 'revenue' : 'units';
+            };
+            const hasVizKeyword = /(visuali[sz]e|chart|plot|graph)/i.test(messageText) || /(visuali[sz]e|chart|plot|graph)/i.test(content);
+            const hasVizSuggestion = suggestions.some(s => /(visuali[sz]e|chart|plot|graph)/i.test(s));
+            const mentionsDataSignals = /(trend|seasonality|units|revenue|time\s*series)/i.test(content + ' ' + messageText);
+            const hasNumbers = /\d{2,}/.test(content);
 
-            if(shouldVisualize && state.selectedLob?.hasData && state.selectedLob?.mockData) {
+            let visualization;
+            const shouldVisualize = state.selectedLob?.hasData && state.selectedLob?.mockData && (hasVizKeyword || hasVizSuggestion || (mentionsDataSignals && hasNumbers));
+
+            if (shouldVisualize) {
+                const combined = `${messageText} ${content} ${suggestions.join(' ')}`;
                 visualization = {
-                    data: state.selectedLob.mockData,
-                    target: 'units' as 'units' | 'revenue',
+                    data: state.selectedLob!.mockData!,
+                    target: inferTargetFromText(combined),
                     isShowing: false,
-                }
+                };
             }
 
 

--- a/src/components/dashboard/data-panel.tsx
+++ b/src/components/dashboard/data-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -8,51 +8,115 @@ import DataVisualizer from "./data-visualizer";
 import { useApp } from "./app-provider";
 import BuLobSelector from "./bu-lob-selector";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 export default function DataPanel({ className }: { className?: string }) {
-  const { state } = useApp();
-  const [target, setTarget] = useState<"units" | "revenue">("units");
+  const { state, dispatch } = useApp();
 
   const vizData = useMemo(() => state.selectedLob?.mockData ?? null, [state.selectedLob]);
+
+  useEffect(() => {
+    // Ensure target reflects state
+    if (!['units','revenue'].includes(state.dataPanelTarget)) {
+      dispatch({ type: 'SET_DATA_PANEL_TARGET', payload: 'units' });
+    }
+  }, [state.dataPanelTarget, dispatch]);
 
   return (
     <Card className={cn("flex flex-col rounded-none border-0 md:border-r", className)}>
       <CardHeader className="p-4 border-b">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-lg">Data Visualization</CardTitle>
+          <CardTitle className="text-lg">Insights Panel</CardTitle>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="ghost" onClick={() => dispatch({ type: 'SET_DATA_PANEL_OPEN', payload: false })}>
+              Hide
+            </Button>
+          </div>
+        </div>
+        <div className="mt-2 flex items-center justify-between gap-2">
+          <BuLobSelector />
           <div className="flex items-center gap-2">
             <Button
               size="sm"
-              variant={target === "units" ? "secondary" : "ghost"}
-              onClick={() => setTarget("units")}
+              variant={state.dataPanelTarget === "units" ? "secondary" : "ghost"}
+              onClick={() => dispatch({ type: 'SET_DATA_PANEL_TARGET', payload: 'units' })}
             >
               Units
             </Button>
             <Button
               size="sm"
-              variant={target === "revenue" ? "secondary" : "ghost"}
-              onClick={() => setTarget("revenue")}
+              variant={state.dataPanelTarget === "revenue" ? "secondary" : "ghost"}
+              onClick={() => dispatch({ type: 'SET_DATA_PANEL_TARGET', payload: 'revenue' })}
             >
               Revenue
             </Button>
           </div>
         </div>
-        <div className="mt-2">
-          <BuLobSelector />
-        </div>
       </CardHeader>
       <CardContent className="p-0 flex-1 min-h-0">
-        <ScrollArea className="h-full">
-          <div className="p-4">
-            {vizData ? (
-              <DataVisualizer data={vizData} target={target} />
-            ) : (
-              <div className="text-center text-sm text-muted-foreground py-10 px-4 border rounded-md bg-muted/30">
-                Select a Business Unit / LOB with data to see charts here.
-              </div>
-            )}
+        <Tabs value={state.dataPanelMode} onValueChange={(v) => dispatch({ type: 'SET_DATA_PANEL_MODE', payload: v as any })} className="flex flex-col h-full">
+          <div className="px-4 pt-3">
+            <TabsList>
+              <TabsTrigger value="chart">Chart</TabsTrigger>
+              <TabsTrigger value="table">Table</TabsTrigger>
+              <TabsTrigger value="menu">Menu</TabsTrigger>
+            </TabsList>
           </div>
-        </ScrollArea>
+          <TabsContent value="chart" className="flex-1 min-h-0">
+            <ScrollArea className="h-full">
+              <div className="p-4">
+                {vizData ? (
+                  <DataVisualizer data={vizData} target={state.dataPanelTarget} />
+                ) : (
+                  <div className="text-center text-sm text-muted-foreground py-10 px-4 border rounded-md bg-muted/30">
+                    Select a Business Unit / LOB with data to see charts here.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent value="table" className="flex-1 min-h-0">
+            <ScrollArea className="h-full">
+              <div className="p-4">
+                {vizData ? (
+                  <Table>
+                    <TableCaption>Weekly {state.dataPanelTarget} for {state.selectedLob?.name}</TableCaption>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Week</TableHead>
+                        <TableHead>Date</TableHead>
+                        <TableHead className="text-right capitalize">{state.dataPanelTarget}</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {vizData.map((row, i) => (
+                        <TableRow key={i}>
+                          <TableCell>{row.week}</TableCell>
+                          <TableCell>{new Date(row.date).toLocaleDateString()}</TableCell>
+                          <TableCell className="text-right">{(row as any)[state.dataPanelTarget]?.toLocaleString?.() ?? '—'}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : (
+                  <div className="text-center text-sm text-muted-foreground py-10 px-4 border rounded-md bg-muted/30">
+                    Select a Business Unit / LOB with data to see a table here.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+          <TabsContent value="menu" className="flex-1 min-h-0">
+            <ScrollArea className="h-full">
+              <div className="p-4 grid gap-2">
+                <Button variant="outline" onClick={() => dispatch({ type: 'SET_DATA_PANEL_MODE', payload: 'chart' })}>Show Chart</Button>
+                <Button variant="outline" onClick={() => dispatch({ type: 'SET_DATA_PANEL_MODE', payload: 'table' })}>Show Table</Button>
+                <Button variant="outline" onClick={() => dispatch({ type: 'SET_DATA_PANEL_OPEN', payload: false })}>Close Panel</Button>
+              </div>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/main-content.tsx
+++ b/src/components/dashboard/main-content.tsx
@@ -7,17 +7,45 @@ import ChatPanel from "./chat-panel";
 import WelcomeHero from "./welcome-hero";
 
 export default function MainContent() {
-  const { state } = useApp();
+  const { state, dispatch } = useApp();
 
   if (state.isOnboarding) {
     return <WelcomeHero />;
   }
 
   if (state.dataPanelOpen) {
+    const leftPct = state.dataPanelWidthPct;
+    const rightPct = 100 - leftPct;
+
+    const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startLeft = leftPct;
+      const onMove = (ev: MouseEvent) => {
+        const dx = ev.clientX - startX;
+        const w = document.body.clientWidth || window.innerWidth;
+        const deltaPct = (dx / w) * 100;
+        dispatch({ type: 'SET_DATA_PANEL_WIDTH', payload: startLeft + deltaPct });
+      };
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    };
+
     return (
-      <main className="flex flex-1 overflow-hidden flex-col md:flex-row">
-        <DataPanel className="w-full md:w-1/2" />
-        <div className="w-full md:w-1/2 flex flex-col overflow-hidden">
+      <main className="flex flex-1 overflow-hidden">
+        <div style={{ width: `${leftPct}%` }} className="min-w-[20%] max-w-[70%]">
+          <DataPanel className="w-full h-full" />
+        </div>
+        <div
+          onMouseDown={onMouseDown}
+          className="w-1 cursor-col-resize bg-border hover:bg-primary/40 transition-colors"
+          title="Drag to resize"
+        />
+        <div style={{ width: `${rightPct}%` }} className="flex flex-col overflow-hidden">
           <ChatPanel className="flex-1" />
         </div>
       </main>

--- a/src/components/dashboard/welcome-hero.tsx
+++ b/src/components/dashboard/welcome-hero.tsx
@@ -43,7 +43,7 @@ export default function WelcomeHero() {
 
           <div className="mt-6 mx-auto max-w-3xl">
             <div className="rounded-2xl border bg-card/60 backdrop-blur supports-[backdrop-filter]:bg-card/40 p-3 shadow-lg">
-              <div className="flex items-center gap-2">
+              <form className="flex items-center gap-2" onSubmit={(e) => { e.preventDefault(); start(); }}>
                 <Bot className="h-5 w-5 text-muted-foreground" />
                 <Input
                   value={prompt}
@@ -52,10 +52,10 @@ export default function WelcomeHero() {
                   className="flex-1 border-0 focus-visible:ring-0 bg-transparent"
                 />
                 <BuLobSelector compact variant="secondary" size="sm" className="mr-2" triggerLabel="Connectors" />
-                <Button size="sm" onClick={start} disabled={!canContinue}>
+                <Button size="sm" type="submit" disabled={!canContinue}>
                   Start
                 </Button>
-              </div>
+              </form>
             </div>
             <div className="mt-3 flex flex-wrap justify-center gap-2">
               {[


### PR DESCRIPTION
## Changes Made

### Bug Fix
- **Fixed prompt syntax error** in `chatbot-summarize-data.ts`
  - Removed extra single quote at end of prompt string

### Data Panel Enhancements
- **Added tabbed interface** with Chart, Table, and Menu views
- **Added resizable panel** with drag-to-resize functionality (20-70% width)
- **Enhanced state management** with new data panel properties:
  - `dataPanelMode`: Controls active tab ('chart' | 'table' | 'menu')
  - `dataPanelTarget`: Data target ('units' | 'revenue') 
  - `dataPanelWidthPct`: Panel width percentage (20-70)

### Chat Panel Improvements
- **Improved visualization detection** with better keyword matching
- **Auto-target inference** from message content (revenue vs units)
- **Enhanced duplicate message prevention** in message reducer
- **Better visualization triggering** based on data signals and numbers

### UI/UX Improvements
- **Renamed panel** from "Data Visualization" to "Insights Panel"
- **Added table view** showing weekly data with proper formatting
- **Improved layout** with better responsive design
- **Added form submission** to welcome hero for Enter key support
- **Enhanced button interactions** and state synchronization

### Technical Changes
- Added new reducer actions for data panel state management
- Implemented mouse event handlers for panel resizing
- Added proper TypeScript types for new state properties
- Enhanced component props and state flowTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc950595c180414d95bbeeb266c5c6a3/echo-forge)

👀 [Preview Link](https://dc950595c180414d95bbeeb266c5c6a3-echo-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc950595c180414d95bbeeb266c5c6a3</projectId>-->
<!--<branchName>echo-forge</branchName>-->